### PR TITLE
Create .gitattribute and .editorconfig files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.js    eol=lf
+*.jsx   eol=lf
+*.json  eol=lf


### PR DESCRIPTION
When the Git repo is cloned with the .gitattributes and .editorconfig file, the Eslint no longer shows line break styling problems on Windows

Closes #47 

Before
![image](https://user-images.githubusercontent.com/8210763/103842934-c1da2380-504b-11eb-85f2-d35fbc5261b3.png)

After
![image](https://user-images.githubusercontent.com/8210763/103842994-d74f4d80-504b-11eb-9f6f-02eb18ba85c8.png)
