### PR TITLE
Add required permissions for Organizer on start up

### DIFF
--- a/server/config/functions/bootstrap.js
+++ b/server/config/functions/bootstrap.js
@@ -32,34 +32,34 @@ module.exports = async () => {
 
   await setDefaultRole();
 
-  // prettier-ignore
-  { // block is here purely to stop prettier
-    await setPermission("public", "application", "event",   "find",     true);
-    await setPermission("public", "application", "event",   "findone",  true);
-    await setPermission("public", "application", "talk",    "find",     true);
-    await setPermission("public", "application", "talk",    "findone",  true);
-    await setPermission("speaker", "application", "talk",   "create",   true);
+  await setPermission("public", "application", "event", "find", true);
+  await setPermission("public", "application", "event", "findone", true);
+  await setPermission("public", "application", "talk", "find", true);
+  await setPermission("public", "application", "talk", "findone", true);
 
-    await setPermission("speaker", "application", "event",  "find",     true);
-    await setPermission("speaker", "application", "event",  "findone",  true);
-    await setPermission("speaker", "application", "talk",   "find",     true);
-    await setPermission("speaker", "application", "talk",   "findone",  true);
-    await setPermission("speaker", "application", "talk",   "create",   true);
+  await setPermission("speaker", "application", "event", "find", true);
+  await setPermission("speaker", "application", "event", "findone", true);
+  await setPermission("speaker", "application", "talk", "find", true);
+  await setPermission("speaker", "application", "talk", "findone", true);
+  await setPermission("speaker", "application", "talk", "create", true);
 
-    await setPermission("authenticated", "application", "event",  "count",    true);
-    await setPermission("authenticated", "application", "event",  "create",   true);
-    await setPermission("authenticated", "application", "event",  "delete",   true);
-    await setPermission("authenticated", "application", "event",  "find",     true);
-    await setPermission("authenticated", "application", "event",  "findone",  true);
-    await setPermission("authenticated", "application", "event",  "update",   true);
+  await setPermission("authenticated", "users-permissions", "user", "find", true);
+  await setPermission("authenticated", "users-permissions", "user", "create", true);
+  await setPermission("authenticated", "users-permissions", "user", "destroy", true);
 
-    await setPermission("authenticated", "application", "talk",   "count",    true);
-    await setPermission("authenticated", "application", "talk",   "create",   true);
-    await setPermission("authenticated", "application", "talk",   "delete",   true);
-    await setPermission("authenticated", "application", "talk",   "find",     true);
-    await setPermission("authenticated", "application", "talk",   "findone",  true);
-    await setPermission("authenticated", "application", "talk",   "update",   true);
-  }
+  await setPermission("authenticated", "application", "event", "count", true);
+  await setPermission("authenticated", "application", "event", "create", true);
+  await setPermission("authenticated", "application", "event", "delete", true);
+  await setPermission("authenticated", "application", "event", "find", true);
+  await setPermission("authenticated", "application", "event", "findone", true);
+  await setPermission("authenticated", "application", "event", "update", true);
+
+  await setPermission("authenticated", "application", "talk", "count", true);
+  await setPermission("authenticated", "application", "talk", "create", true);
+  await setPermission("authenticated", "application", "talk", "delete", true);
+  await setPermission("authenticated", "application", "talk", "find", true);
+  await setPermission("authenticated", "application", "talk", "findone", true);
+  await setPermission("authenticated", "application", "talk", "update", true);
 };
 
 async function initializeAdmin() {


### PR DESCRIPTION
This change assigns the Organizer role the permissions of find, create, and destroy Users when the server start up.

This will help avoid manually setting the permissions when a developer sets up application in new environment.

![image](https://user-images.githubusercontent.com/8210763/104870589-bf09e900-58fd-11eb-8e75-8053bd980578.png)

Closes #50 