### PR TITLE
Fix unhandled error caused by failed login

### DIFF
--- a/client/pages/admin/signin.js
+++ b/client/pages/admin/signin.js
@@ -18,23 +18,33 @@ const AdminSignin = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    const response = await fetch(`${process.env.API_BASE_URL}/auth/local`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        identifier: data.identifier,
-        password: data.password,
-      }),
-    });
-    const responseData = await response.json();
-    setToken(responseData, router);
+    try {
+      const response = await fetch(`${process.env.API_BASE_URL}/auth/local`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          identifier: data.identifier,
+          password: data.password,
+        }),
+      });
 
-    const userCookie = Cookies.get('username');
-    if (userCookie) {
-      setUser(userCookie);
-      router.push('/admin/meetups');
+      const responseData = await response.json();
+
+      if (responseData.error) {
+        throw Error(responseData.data[0].messages[0].message);
+      }
+
+      setToken(responseData, router);
+
+      const userCookie = Cookies.get('username');
+      if (userCookie) {
+        setUser(userCookie);
+        router.push('/admin/meetups');
+      }
+    } catch (error) {
+      alert(error);
     }
   };
 


### PR DESCRIPTION
Based on comments left in PR #38

Solution uses a try/catch block so async/await are used instead of chained promise methods of .then()

Closes #37 

![image](https://user-images.githubusercontent.com/8210763/104977088-8f1d1d00-59b3-11eb-9e74-b964b7a94b0f.png)
