### PR TITLE
Fix Meetups API call for day of month

### DIFF
--- a/server/config/functions/meetups.js
+++ b/server/config/functions/meetups.js
@@ -4,7 +4,7 @@ module.exports = async () => {
   return new Promise((resolve, reject) => {
 		let currentDate = new Date();
 		currentDate.setMonth(currentDate.getMonth() + 3);
-		const date = `${currentDate.getFullYear()}-${currentDate.getMonth()}-${currentDate.getDay()}`;
+		const date = `${currentDate.getFullYear()}-${currentDate.getMonth()}-${currentDate.getDate()}`;
 		axios.get(`https://api.meetup.com/sandiegojs/events?no_later_than=${date}`)
 		.then( response => resolve(response.data.map(event => ({
 			meetupId: event.id,


### PR DESCRIPTION
The Date() .getDay() returns the day of the week, replacing with .getDate() which is the day of the month.

When the day was a Monday it would set the day to 0, the Meetups API would error on invalid dates.

I believe this may close Issue #44 so I am linking it.

Closes #44

![image](https://user-images.githubusercontent.com/8210763/104978586-fb4d5000-59b6-11eb-909e-eb14b06d38c6.png)
